### PR TITLE
Improve README clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,87 @@
 # Lyrebird Mini Tech
 
+Lyrebird Mini Tech is a small demo application that showcases a speech dictation workflow built with **FastAPI** and **Streamlit**. Audio is transcribed using OpenAI's `whisper-1` model, formatted with user preferences and stored in PostgreSQL. The project integrates with **LangSmith** for prompt management and tracing.
 
+![Function Page](./assets/function_page.png)
 
-## Function Page
-![image](./assets/function_page.png)
+## Features
 
+- **FastAPI backend** with authentication and PostgreSQL models
+- **Streamlit frontend** for uploading audio and viewing formatted results
+- **OpenAI Whisper** audio transcription and GPT formatting
+- **User preference extraction** from edited text
+- **LangSmith integration** for tracing and prompt storage
+- **Alembic migrations** for database setup
 
+## Getting Started
 
-## What has implemented 
+### Docker Compose (recommended)
 
-- **Backend API** with table models, integrated with PostgreSQL
-  - API routes: `/api/src/users/routes.py` and `/api/src/dictations/routes.py`
-  - Database models: `/api/src/users/models.py` and `/api/src/dictations/models.py`
-  - Database connection: `/api/core/database.py`
-- **Frontend** with Streamlit
-  - Implementation: `/frontend/streamlit_app.py`
-- **Alembic migration** database initialization
-  - Migration scripts: `/alembic/versions/`
-- **Langsmith trace** integration
-  - Implementation: `/api/src/dictations/service.py`
-  - OpenAI client wrapper: `_langsmith_trace_wrapper()` method
-  - Configuration: `/api/core/config.py`
-- **Langsmith prompt management**, supporting further iteration and evaluation with Langsmith toolkit
-  - Prompt synchronization: `/api/llm/sync_prompt.py`
-  - Prompt usage: `/api/src/dictations/service.py`
-- **Streamlit front-end** application
-  - Implementation: `/frontend/streamlit_app.py`
-
-
-
-# Setup
-
-
-## How to setup with docker-compose(Recommended)
-
-The mock data will be also injected when you start the services with docker-compose.
-
-After configuration on .env.docker with necessary environment variables, you can start the services with docker-compose.
-
+1. Copy `.env.docker.example` to `.env.docker` and adjust the values.
+2. Start the services:
 
 ```bash
 make start-service
 ```
 
-Frontend will be available at http://localhost:8501
-Backend API will be available at http://localhost:8000/docs
+The UI will be available at [http://localhost:8501](http://localhost:8501) and the API docs at [http://localhost:8000/docs](http://localhost:8000/docs).
+Use `1@2.com` with password `1` to sign in to the demo.
 
-Frontend login with username: `1@2.com` and password: `1`
+### Local Development
 
-
-## How to setup in local environment 
-I have created a Makefile to help you setup the environment with commands.
-
-### Prepare python environment
-
-1. install uv
-
-https://docs.astral.sh/uv/getting-started/installation/
-
-2. create virtual environment
-
-
-https://docs.astral.sh/uv/pip/environments/
-
-
-### Prepare .env file
-1. copy .env.example to .env, use this template to fill in the .env file
-
-
-### Prepare database
-
-1. start docker
+1. Install [uv](https://docs.astral.sh/uv/getting-started/installation/) and create a virtual environment:
 
 ```bash
-make start-service
+uv venv
+source .venv/bin/activate
 ```
 
-2. init db with alembic
+2. Install dependencies:
+
+```bash
+uv pip install -r uv.lock
+```
+
+3. Copy `.env.docker.example` to `.env` and update the environment variables. A minimal configuration looks like:
+
+```env
+PROJECT_NAME="Lyrebird Mini Tech API"
+ENV=local
+POSTGRES_SERVER=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=app
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=lyrebird
+JWT_SECRET="change-me-in-production"
+OPENAI_API_KEY="your-openai-api-key"
+LANGSMITH_TRACING=true
+LANGSMITH_ENDPOINT="https://api.smith.langchain.com"
+LANGSMITH_API_KEY="your-langsmith-api-key"
+LANGSMITH_PROJECT="your-langsmith-project"
+API_BASE_URL="http://backend:8000"
+```
+
+4. Start the local Postgres service (this only creates the database instance):
+
+```bash
+make start-service-local
+```
+
+5. Initialize the database schema:
+
 ```bash
 make init-db
 ```
 
+6. Run the development servers:
 
-### Start the dev server
 ```bash
 make dev-fastapi
 ```
 
-### Start the dev frontend
+In a separate terminal:
+
 ```bash
 make dev-frontend
 ```
-
 


### PR DESCRIPTION
## Summary
- rewrite the README with a short project overview and feature list
- add clear setup instructions and environment variable example
- clarify that local development should start Postgres via `start-service-local`

## Testing
- `make test` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e7dbb9e0832db75c8ed9c11e1df4